### PR TITLE
Add a link to `backdropsend` repo

### DIFF
--- a/sending-data-to-backdrop.rst
+++ b/sending-data-to-backdrop.rst
@@ -13,6 +13,8 @@ In summary:
 - The content and content type must be JSON.
 - There must be a valid Authorization header.
 
+The .. _backdropsend: https://github.com/alphagov/backdropsend tool provides a command line interface to the API.
+
 See the example below using curl (all examples using curl 7.24)::
 
   curl -X POST -d '{"name":"Jane"}' -H 'Authorization: Bearer <your-token>' -H 'Content-type: application/json' 'http://<backdrop-write-host>/<bucket-name>'


### PR DESCRIPTION
I had not heard of this helpful CLI tool until this:
https://github.com/alphagov/backdrop/pull/222
