### PR TITLE
Improve copy on docs welcome page. Focus on spotlight not limelight.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,19 +1,21 @@
 The Performance Platform Manual
 ===============================
 
-Central government in the UK handles over 1&frac12; billion transactions per year. We're using data to help improve them.
+Central government in the UK handles over 1½ billion transactions per year. We're using data to help improve them.
 
-The [Performance Platform](https://www.gov.uk/performance) is a set of tools for finding out how your service is performing and how it can be improved. Take a look at a few examples to get an idea of what we do:
+The `Performance Platform <https://www.gov.uk/performance>`_ is a set of tools
+for finding out how your service is performing and how it can be improved.
+Take a look at a few examples to get an idea of what we do:
 
-* [Carer's Allowance applications](https://www.gov.uk/performance/carers-allowance)
-* [Lasting Power of Attorney registrations](https://www.gov.uk/performance/lasting-power-of-attorney)
-* [Tax disc renewals](https://www.gov.uk/performance/tax-disc)
+- `Carer's Allowance applications <https://www.gov.uk/performance/carers-allowance>`_
+- `Lasting Power of Attorney registrations <https://www.gov.uk/performance/lasting-power-of-attorney>`_
+- `Tax disc renewals <https://www.gov.uk/performance/tax-disc>`_
 
 Several different apps make up the performance platform.
 
-* **Collectors** take your data and feed it into the performance platform
-* **Backdrop** stores data and lets you retrieve it using standardised commands
-* **Spotlight** displays your data in a dashboard, using a range of module designs
+- **Collectors** take your data and feed it into the performance platform
+- **Backdrop** stores data and lets you retrieve it using standardised commands
+- **Spotlight** displays your data in a dashboard, using a range of module designs
 
 
 .. image:: https://docs.google.com/drawings/d/1Kmz0PIsozcMSef-CoBRkx7jexoqEHbSHbdHO-H07WTM/pub?w=960&amp;h=720


### PR DESCRIPTION
I don't know how to regenerate the first page of the docs, but I have written the markdown.
