### PR TITLE
Fix table formatting

### DIFF
--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -1,0 +1,10 @@
+/* override table width restrictions */
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+}
+
+.wy-table-responsive {
+    margin-bottom: 24px;
+    max-width: 100%;
+    overflow: visible;
+}

--- a/conf.py
+++ b/conf.py
@@ -126,6 +126,13 @@ html_title = "Performance Platform Manual"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# See https://github.com/snide/sphinx_rtd_theme/issues/117
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # overrides for wide tables in RTD theme
+        ],
+    }
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
http://alphagov.github.io/performanceplatform-documentation/users/stories.html
 is very badly formatted by default. We can override that until upstream 
https://github.com/snide/sphinx_rtd_theme adds defaults that we agree with.
