### PR TITLE
User-manual-skeleton

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -18,6 +18,7 @@ Take a look at a few examples to get an idea of what we do:
    integrating/index
    architecture/index
    roadmap/index
+   user-manual/index
    About <about>
    glossary
 

--- a/user-manual/building-a-dashboard/configuring-the-dashboard/index.rst
+++ b/user-manual/building-a-dashboard/configuring-the-dashboard/index.rst
@@ -1,0 +1,30 @@
+.. _configuring-the-dashboard:
+
+Configuring the dashboard
+#########################
+
+Pre-reqs
+
+How to config
+
+selection of modules
+
+org/service specific copy ....
+
+Purpose:
+--------
+
+Roles:
+------
+
+Pre-requisites:
+---------------
+
+Outputs:
+--------
+
+Constraints:
+------------
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/building-a-dashboard/configuring-the-repository/index.rst
+++ b/user-manual/building-a-dashboard/configuring-the-repository/index.rst
@@ -1,0 +1,30 @@
+.. _configuring-the-repository:
+
+Configuring the platform repository
+###################################
+
+Pre-reqs
+
+How to config
+
+selection of modules
+
+org/service specific copy ....
+
+Purpose:
+--------
+
+Roles:
+------
+
+Pre-requisites:
+---------------
+
+Outputs:
+--------
+
+Constraints:
+------------
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/building-a-dashboard/deploying-the-dashboard/index.rst
+++ b/user-manual/building-a-dashboard/deploying-the-dashboard/index.rst
@@ -1,0 +1,28 @@
+.. _deploying-the-dashboard:
+
+Deploying the dashboard
+#######################
+
+Pre-reqs
+
+How to config
+
+Timings - copies and migrations
+
+Purpose:
+--------
+
+Roles:
+------
+
+Pre-requisites:
+---------------
+
+Outputs:
+--------
+
+Constraints:
+------------
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/building-a-dashboard/determining-the-metrics/index.rst
+++ b/user-manual/building-a-dashboard/determining-the-metrics/index.rst
@@ -1,0 +1,32 @@
+.. _determining-the-metrics:
+
+Determining the metrics
+#######################
+
+KPI's - de facto
+
+Advised metrics - optinos available
+
+Other service specific metrics
+
+Scope metrics in context of others service/transactions within the organisation
+
+Identify sources and criteria for ensuring unique/context
+
+Purpose:
+--------
+
+Roles:
+------
+
+Pre-requisites:
+---------------
+
+Outputs:
+--------
+
+Constraints:
+------------
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/building-a-dashboard/identifying-data-sources/index.rst
+++ b/user-manual/building-a-dashboard/identifying-data-sources/index.rst
@@ -1,0 +1,33 @@
+.. _identifying-data-sources:
+
+Identifying data sources
+########################
+
+Tandem activity to determining the dashboard metrics
+
+Context
+
+Data source
+
+auto/manual integration
+
+direct access to data OR proxied (hmrc!!!!!)
+
+Purpose:
+--------
+
+Roles:
+------
+
+Pre-requisites:
+---------------
+
+Outputs:
+--------
+
+Constraints:
+------------
+
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/building-a-dashboard/index.rst
+++ b/user-manual/building-a-dashboard/index.rst
@@ -1,0 +1,60 @@
+.. _building-a-dashboard:
+
+Building a dashboard
+####################
+
+The process
+===========
+
+Nice picture of the 'flow' of dashboard delivery
+
+Outline broad pahses and types of role/engagment
+
+Business analysis
+-----------------
+
+* `Understanding the service in context`_ - One liner!
+* `Determining the metrics`_ - one liner!
+* `Scoping the dashboard`_ - one liner
+
+Technical analysis
+------------------
+
+* `Identifying data sources`_ - one liner!
+
+Configuration, build and integration
+------------------------------------
+
+* `Configuring the platform repository`_ - one liner
+* `Integrating data sources`_ - one liner
+
+Dashboard configuration
+-----------------------
+
+* `Configuring the dashboard`_ - one liner!
+
+Deployment
+----------
+
+* `Deploying the dashboard`_ - one liner!
+
+.. _Understanding the service in context: service-in-context
+.. _Determining the metrics: determining-the-metrics
+.. _Scoping the dashboard: scoping-the-dashboard
+.. _Identifying data sources: identifying-data-sources
+.. _Configuring the platform repository: configuring-the-repository
+.. _Integrating data sources: integrating-data-sources
+.. _Configuring the dashboard: configuring-the-dashboard
+.. _Deploying the dashboard: deploying-the-dashboard
+
+.. toctree::
+  :hidden:
+  
+  service-in-context/index
+  determining-the-metrics/index
+  scoping-the-dashboard/index
+  identifying-data-sources/index
+  configuring-the-repository/index
+  integrating-data-sources/index
+  configuring-the-dashboard/index
+  deploying-the-dashboard/index

--- a/user-manual/building-a-dashboard/integrating-data-sources/index.rst
+++ b/user-manual/building-a-dashboard/integrating-data-sources/index.rst
@@ -1,0 +1,35 @@
+.. _integrating-data-sources:
+
+Integrating data sources
+########################
+
+Checklists for:
+
+PP Collector config
+
+Bespokes - auto/manual
+
+considerations:
+push/pull - collector-direct
+internet/intranet
+data qual
+security
+user anonymous data
+
+Purpose:
+--------
+
+Roles:
+------
+
+Pre-requisites:
+---------------
+
+Outputs:
+--------
+
+Constraints:
+------------
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/building-a-dashboard/scoping-the-dashboard/index.rst
+++ b/user-manual/building-a-dashboard/scoping-the-dashboard/index.rst
@@ -1,0 +1,27 @@
+.. _scoping-the-dashboard:
+
+Scoping the dashboard
+#####################
+
+overarching principles 
+
+understand dashboard in context of managed services -how data will likely be aggregated etc
+
+Purpose:
+--------
+
+Roles:
+------
+
+Pre-requisites:
+---------------
+
+Outputs:
+--------
+
+Constraints:
+------------
+
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/building-a-dashboard/service-in-context/index.rst
+++ b/user-manual/building-a-dashboard/service-in-context/index.rst
@@ -1,0 +1,29 @@
+.. _service-in-context:
+
+Understanding the service in context
+####################################
+
+Build the map of:
+* the service
+* any variants
+* the service transaction
+* the channels
+To provide a context to aid scoping of dashboards and collector
+
+Purpose:
+========
+
+Roles:
+======
+
+Pre-requisites:
+===============
+
+Outputs:
+========
+
+Constraints:
+============
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/contributing/index.rst
+++ b/user-manual/contributing/index.rst
@@ -1,0 +1,22 @@
+.. _contributing:
+
+How to get involved
+###################
+
+Ways for users of the platfomr to contribute to its success
+
+Feature proposals
+-----------------
+
+Feedback on experimental work - preferred ways to expose metrics
+----------------------------------------------------------------
+
+Contributing to the platformcodebase
+------------------------------------
+
+Contributing bespoke collector code
+-----------------------------------
+
+
+... and many many more!
+

--- a/user-manual/dashboards/aggregate-dashboards/index.rst
+++ b/user-manual/dashboards/aggregate-dashboards/index.rst
@@ -1,0 +1,15 @@
+.. _aggregate-dashboards:
+
+Aggregate dashboards
+####################
+
+Purpose
+-------
+
+IMAGE
+
+Components
+----------
+
+Examples
+--------

--- a/user-manual/dashboards/high-volume-service-dashboards/index.rst
+++ b/user-manual/dashboards/high-volume-service-dashboards/index.rst
@@ -1,0 +1,15 @@
+.. _high-volume-service-dashboards:
+
+High volume service dashboards
+##############################
+
+Purpose
+-------
+
+IMAGE
+
+Components
+----------
+
+Examples
+--------

--- a/user-manual/dashboards/index.rst
+++ b/user-manual/dashboards/index.rst
@@ -1,0 +1,106 @@
+.. _dashboards:
+
+Dashboards
+##########
+
+The performance platform is built to support a flexible ..........
+
+Dependent on the subject of a dashbaord: service transactions, service aggregates ....., 
+the performance platfomr have a number of templates that reflect the type of 'thing' being
+measured and the metrics that are regularly prsented for those 'things'
+
+Types of dashboard
+------------------
+* `Transactional service dashboards`_ - one liner
+* `KPI dashboards`_ - one liner
+* `Aggregate dashboards`_ - one liner
+* `Service overview dashboards`_ - one liner
+* `High volume service dashboards`_ - one liner
+* `Low volume service dashboards`_ - one liner
+
+NOTE - Think there should be Service transaction group/Service/Service group dashboards for intermediaries
+
+Choosing the dashboard type
+---------------------------
+
+The dasshboard types listed above are templates for presenting metrics.  They allow flexible combination of 
+metrics modules to provide the broadest overview of how a service or transactional service are operating and 
+allow users to ......
+
+The service manager has control over which metrics to display on which dashboard .... need some notes/guidance 
+on what modules of what metrics make sense
+
+Selecting the user view
+-----------------------
+Some blurb re. the focus of the dashboard groupings - transactional services - it is about the user.
+Aggeragtion of dashboard can be both a reflection of the transaction end-user view (IMPORTANT), but also
+the view for the service manager operating within an organisation (see hierarchy of service)
+Need to maybe show picture/graph of how the same metrics can be presented in different groupings dependent
+on the primary audiences
+
+Metrics mapping
+---------------
+
+The table below shows (from working with existing service managers) which metrics (and as a consequence modules)
+can/should be present on which type of dashboard
+
+**Metrics - Dashboard Map**
+
++----------------------------+----------------------+--------------------------------------------------------------------------+
+|                            |Dashboard type                                                                                   |
++                            +----------------------+-------------------+------------+--------------------+--------------------+
+|Metric                      |Transactional service |KPI                |*other-tbc* |High volume service |Low volume service  |
++============================+======================+===================+============+====================+====================+
+|cost per transaction        |optional\ :sup:`1`    |optional\ :sup:`1` |            |mandatory           |                    |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|user satisfaction           |mandatory             |mandatory          |            |optional\ :sup:`2`  |                    |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|completion rate             |mandatory             |mandatory          |            |optional\ :sup:`2`  |                    |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|digital take-up             |mandatory             |mandatory          |            |optional\ :sup:`2`  |                    |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|live service usage          |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|transactions by channel     |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|completion at each stage    |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|page load time              |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|service uptime              |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|transaction volumes         |optional              |*n/a*              |            |mandatory\ :sup:`3` |mandatory\ :sup:`3` |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|site visits                 |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|device usage                |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|browser usage               |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|help usage                  |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|bespoke                     |optional              |*n/a*              |            |*n/a*               |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+|digital transaction volumes |optional              |                   |            |optional \ :sup:`3` |*n/a*               |
++----------------------------+----------------------+-------------------+------------+--------------------+--------------------+
+
+:sup:`1` - organisations may not be able to break down the *cost per transaction* at the transactional service level. It **MUST** per provided on an alternative dashboard at the appropriate level of aggregation.
+
+KPI dashboards     Aggregate dashboards Service overview dashboards High volume service dashboards Low volume service dashboards
+
+.. _`Transactional service dashboards`: transactional-service-dashboards/index.html
+.. _`KPI dashboards`: kpi-dashboards/index.html
+.. _`Aggregate dashboards`: aggregate-dashboards/index.html
+.. _`Service overview dashboards`: service-overview-dashboards/index.html
+.. _`High volume service dashboards`: high-volume-service-dashboards/index
+.. _`Low volume service dashboards`: low-volume-service-dashboards/index
+
+.. toctree::
+  :hidden:
+  
+  transactional-service-dashboards/index
+  kpi-dashboards/index
+  aggregate-dashboards/index
+  service-overview-dashboards/index
+  high-volume-service-dashboards/index
+  low-volume-service-dashboards/index

--- a/user-manual/dashboards/kpi-dashboards/index.rst
+++ b/user-manual/dashboards/kpi-dashboards/index.rst
@@ -1,0 +1,15 @@
+.. _kpi-dashboards:
+
+KPI dashboards
+##############
+
+Purpose
+-------
+
+IMAGE
+
+Components
+----------
+
+Examples
+--------

--- a/user-manual/dashboards/low-volume-service-dashboards/index.rst
+++ b/user-manual/dashboards/low-volume-service-dashboards/index.rst
@@ -1,0 +1,15 @@
+.. _low-volume-service-dashboards:
+
+Low volume service dashboards
+#############################
+
+Purpose
+-------
+
+IMAGE
+
+Components
+----------
+
+Examples
+--------

--- a/user-manual/dashboards/service-overview-dashboards/index.rst
+++ b/user-manual/dashboards/service-overview-dashboards/index.rst
@@ -1,0 +1,15 @@
+.. _service-overview-dashboards:
+
+Service overview dashboards
+###########################
+
+Purpose
+-------
+
+IMAGE
+
+Components
+----------
+
+Examples
+--------

--- a/user-manual/dashboards/transactional-service-dashboards/index.rst
+++ b/user-manual/dashboards/transactional-service-dashboards/index.rst
@@ -1,0 +1,15 @@
+.. _transactional-service-dashboards:
+
+Transactional service dashboards
+################################
+
+Purpose
+-------
+
+IMAGE
+
+Components
+----------
+
+Examples
+--------

--- a/user-manual/data-architecture/data-format/index.rst
+++ b/user-manual/data-architecture/data-format/index.rst
@@ -1,0 +1,18 @@
+.. _data-format:
+
+Data formats 
+############
+
+Consistency, automation, dependable consistency
+
+Media type of choice - json
+
+Use of schema ... goodness and validation
+
+Resource identifies .. reseverd ids etc
+
+Timestamping
+
+Geo ???
+
+Flat structures

--- a/user-manual/data-architecture/datagroup/index.rst
+++ b/user-manual/data-architecture/datagroup/index.rst
@@ -1,0 +1,16 @@
+.. _datagroup:
+
+Datagroup
+#########
+
+Definition: 
+
+How to spot them, what do they look like, what did they have for breakfast today
+
+Defining/naming/mapping to services ...
+
+maybe this can sit in parent page if not too big
+
+Example:
+
+show something with a bit f hierarchy

--- a/user-manual/data-architecture/dataset/index.rst
+++ b/user-manual/data-architecture/dataset/index.rst
@@ -1,0 +1,20 @@
+.. _dataset:
+
+Dataset
+#######
+
+Definition: 
+
+How to spot them, what do they look like, what did they have for breakfast today
+
+Defining/naming/mapping to datagroups/datatypes ...
+
+Rules for sizing/scoping - about sources and datagroup/datatype constructs
+
+Issues re. ability only build metrics from single dataset - maximisation rules 
+
+Schema's - conforms to the data type
+
+How this forms basis of validation of input and defining storage constructs
+
+Examples:

--- a/user-manual/data-architecture/datatype/index.rst
+++ b/user-manual/data-architecture/datatype/index.rst
@@ -1,0 +1,33 @@
+.. _datatype:
+
+Datatype
+#########
+
+Definition: 
+
+How to spot them, what do they look like, what did they have for breakfast today
+
+Defining/naming/mapping to services ...
+
+Standard sets
+-------------
+
+Customising
+-----------
+
+What can be customeised
+
+ad hoc or ONLY aditive optional extension of standard sets? - limiting but with view of more 'freedom' later?
+
+Uniqueness
+----------
+Need to nail whether absolute or relative to datagroup ... my current thinking is relative
+
+
+
+Schema's ...
+
+How this forms basis of validation of input and defining storage constructs
+
+Examples:
+

--- a/user-manual/data-architecture/index.rst
+++ b/user-manual/data-architecture/index.rst
@@ -1,0 +1,38 @@
+.. _data-architecture:
+
+The data
+########
+
+Its what its all about really!!!
+
+The data architecture
+=====================
+Highlight the importance of having a clear set of data models as part of the overall domain model
+
+Explain for given service and transactions:
+
+Diagram - snippet of the domain model
+
+* `Datagroup`_ - one liner
+* `Datatype`_ one liner
+* `Dataset`_ - one liner
+
+Data formats
+============
+
+To automate and drive self serve .... consistency d- supports validation - allows confidence in the metrics
+
+* `Data format`_ words go here!
+
+.. _`Datagroup`: datagroup/index
+.. _`Datatype`: datatype/index
+.. _`Dataset`: dataset/index
+.. _`Data format`: data-format/index
+
+.. toctree::
+  :hidden:
+
+  datagroup/index
+  datatype/index
+  dataset/index
+  data-format/index

--- a/user-manual/index.rst
+++ b/user-manual/index.rst
@@ -1,0 +1,48 @@
+.. _user-manual:
+
+Performance platform user manual
+################################
+
+Welcome to the Performance Platform User Manual - designed to help government departments and agencies deliver service performance dashboards for their users.
+
+The manual is divided into several sections, each covering different aspects of understanding, commissioning, using or delivering new dashboards on the Performance Platform.
+
+- `Platform overview`_ - if you are new to the Performance Platform, this section introduces the platform, its features and how to use it.
+- `Platform benefits`_ - presenting a consistent view of service performance metrics across government departments offers benefits to service users and managers and decision makers.
+- `Performance metrics`_ - what are the measures that highlight how a service is performing.
+- `Performance dashboards`_ - how does the Performance Platform display performance metrics.
+- `Building a dashboard`_ - the process, activities and responsibilities necessary for the successful delivery of a new dashboard.
+- `Developers`_ - technical detail necessary for developers to build and configure components necessary for the platform to operate, receive data from departments and present them on a dashboard.
+
+The Performance Platform itself follows the `Government Service Design Manual`_ aligning to the `Design Principles`_ and meeting the `Digital by Default Service Standard`_.
+
+There are a number of ways you can help improve the platform for yourself and other users by :ref: `Getting involved`_ .
+**News** - Recent changes to the manual can be found in the `Updates`_
+
+.. _Updates: news.html
+.. _Platform overview: platform-overview.html
+.. _Platform benefits: platform-benefits.html
+.. _Performance metrics: metrics/index.html
+.. _Performance dashboards: dashboards/index.html
+.. _Building a dashboard: building-a-dashboard/index.html
+.. _Developers: developers/index
+.. _Government Service Design Manual: https://www.gov.uk/service-manual
+.. _Design Principles: https://www.gov.uk/designprinciples
+.. _Digital by Default Service Standard: https://www.gov.uk/service-manual/digital-by-default
+.. _Getting involved: contributing/index.html
+
+.. toctree::
+  :hidden:
+
+  platform-overview
+  platform-benefits
+  building-a-dashboard/index
+  metrics/index
+  dashboards/index
+  users/index
+  support/index
+  integration/index
+  modelling-services/index
+  contributing/index
+  news
+

--- a/user-manual/integration/building-your-own-collector/index.rst
+++ b/user-manual/integration/building-your-own-collector/index.rst
@@ -1,0 +1,16 @@
+.. _building-your-own-collector:
+
+Building your own collector
+###########################
+
+Why would you want to do that!
+
+Options in terms of host technologies
+
+Hosting it within organisation estate
+
+RE-usable - hosting on performance platfomr 
+
+Anna's document
+
+Community

--- a/user-manual/integration/implementing-event-monitoring/index.rst
+++ b/user-manual/integration/implementing-event-monitoring/index.rst
@@ -1,0 +1,11 @@
+.. _implementing-event-monitoring:
+
+Implementing event monitoring
+#############################
+
+Overview - near-realtime versus historical 
+
+Types of data:
+
+no users/service availability/page load times
+

--- a/user-manual/integration/index.rst
+++ b/user-manual/integration/index.rst
@@ -1,0 +1,44 @@
+.. _integration:
+
+Integrating with the platform
+#############################
+
+For data input it is about how to get data into dataset (link here to the 'data' section')
+
+Overview
+========
+Ways of integrating with the platform - present integration as serioes of options - pros/cons
+
+* `Integration options`_ - covers the way data sources can be integrated with the platform
+
+Querying performance data
+=========================
+
+Section on how to use the current Read api - link
+
+Data and event uploading
+========================
+
+Once you've agreed the way data can be integrated from identified sources ....
+
+* `Using pre-built collectors`_ - what sources
+* `Building your own collector`_ - text here
+* `Implementing event monitoring`_ - text here
+* `Manual file upload`_ - text here
+
+
+.. _`Integration options`: integration-options
+.. _`Using pre-built collectors`: using-pre-built-collectors
+.. _`Building your own collector`: building-your-own-collector
+.. _`Implementing event monitoring`: implementing-event-monitoring
+.. _`Manual file upload`: uploading-files
+
+.. toctree::
+  :hidden:
+
+  integration-options/index
+  using-pre-built-collectors/index
+  building-your-own-collector/index
+  implementing-event-monitoring/index
+  uploading-files/index
+

--- a/user-manual/integration/integration-options/index.rst
+++ b/user-manual/integration/integration-options/index.rst
@@ -1,0 +1,13 @@
+.. _integration-options:
+
+Integration options
+###################
+
+Architecture view
+
+PICTURE - 
+
+classes/styles of integration
+
+pros and cons
+

--- a/user-manual/integration/uploading-files/index.rst
+++ b/user-manual/integration/uploading-files/index.rst
@@ -1,0 +1,16 @@
+.. _uploading-files:
+
+Manual data file upload
+#######################
+
+it is evil and wrong ... however
+
+When it should be considered
+
+What shape should the data be in
+
+scheduling updates
+
+how to acces the platfomr 
+
+welcome to the admin ui!!!!

--- a/user-manual/integration/using-pre-built-collectors/index.rst
+++ b/user-manual/integration/using-pre-built-collectors/index.rst
@@ -1,0 +1,15 @@
+.. _using-pre-built-collectors:
+
+Using pre-built collectors
+##########################
+
+What is available
+
+what purpose does it serve
+
+what configuration is required
+
+how to map data to datasets - link to data group/type/set and aggregation here
+
+frequency
+

--- a/user-manual/metrics/bespoke/index.rst
+++ b/user-manual/metrics/bespoke/index.rst
@@ -1,0 +1,46 @@
+.. _bespoke:
+
+Bespoke
+#######
+
+Descritpion
+-----------
+
+*outline what the metric provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/browser-usage/index.rst
+++ b/user-manual/metrics/browser-usage/index.rst
@@ -1,0 +1,46 @@
+.. _browser-usage:
+
+Browser usage
+#############
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/completion-at-each-stage/index.rst
+++ b/user-manual/metrics/completion-at-each-stage/index.rst
@@ -1,0 +1,46 @@
+.. _completion-at-each-stage:
+
+Completion at each stage
+########################
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/completion-rate/index.rst
+++ b/user-manual/metrics/completion-rate/index.rst
@@ -1,0 +1,46 @@
+.. _completion-rate:
+
+Completion rate
+###############
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/cost-per-transaction/index.rst
+++ b/user-manual/metrics/cost-per-transaction/index.rst
@@ -1,0 +1,46 @@
+.. _cost-per-transaction:
+
+Cost per transaction
+####################
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/device-usage/index.rst
+++ b/user-manual/metrics/device-usage/index.rst
@@ -1,0 +1,46 @@
+.. _device-usage:
+
+Device usage
+############
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/digital-take-up/index.rst
+++ b/user-manual/metrics/digital-take-up/index.rst
@@ -1,0 +1,46 @@
+.. _digital-take-up:
+
+Digital take-up
+###############
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/help-usage/index.rst
+++ b/user-manual/metrics/help-usage/index.rst
@@ -1,0 +1,46 @@
+.. _help-usage:
+
+Help usage
+##########
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/index.rst
+++ b/user-manual/metrics/index.rst
@@ -1,0 +1,109 @@
+.. _metrics:
+
+Metrics
+#######
+
+The value of `using data <http://www.gov.uk/service-manual/measurement/using-data.html>`_ to direct improvements to service and the benefits of `measurement <https://www.gov.uk/service-manual/measurement>`_ of service performance is outlined in the `Government Service Design Manual <https://www.gov.uk/service-manual>`_.
+
+Key performance indicators (KPI's)
+==================================
+Mandatory KPI's
+---------------
+
+The `Digital by Default Service Standard <https://www.gov.uk/service-manual/digital-by-default>`_ identifies four `mandatory key performance indicators <https://www.gov.uk/service-manual/measurement/other-kpis.html>`_ (KPI's) as a minimum set of measures all new and changed services should monitor and report:
+
+* `KPI: cost per transaction <https://www.gov.uk/service-manual/measurement/cost-per-transaction.html>`_
+* `KPI: user satisfaction <https://www.gov.uk/service-manual/measurement/user-satisfaction.html>`_
+* `KPI: completion rate <https://www.gov.uk/service-manual/measurement/completion-rate.html>`_
+* `KPI: digital take-up <https://www.gov.uk/service-manual/measurement/digital-takeup.html>`_
+
+Other performance indicators
+----------------------------
+
+In addition to the mandatory KPI's, organisations are encouraged to provide additional performance indicators (PI's) relevant to the way users interact with the transactions offered as part of a service.
+
+The Performance Platform recommends the presentation of a number of metrics based on existing Service Manager user need that can be incorporated into both service and service transaction dashboards:
+
+* `Live service usage` - a real time indication of the number of active users on a particular service transaction
+* `Transactions by channel` - a breakdown of user transaction volumes based on how they undertook the transaction - whether online, by telephone, post or other channels
+* `Completion at each journey stage` - online service journeys are generally broken into a number of process stages.  This measure allows the inspection of how many users completed particular stage before completing the transaction
+* `Page load time` - an indication of the time online users wait for pages to load before they can continue the transaction
+* `Service uptime` - a measure of how available the service is to users
+
+In addition to the above metrics, the platform team has identified a number of metrics that may notbe useful to all services, but useful for some:
+
+* `site visits` - a measure of the total volumes of users visiting a site 
+* `device usage` - an indicator of the type of device users use to access a service
+* `browser usage` - an indicator of the browser technology users use to undertake transactions in
+* `help usage` - a measure of the reliance users place on online help while trying to complete a transaction
+
+Other metrics identified by service owners can be presented in graphical or tabular form dependent on need
+
+Details of each metric and how it can be presented on a performance dashboard can be found following the links below:
+
+=========================== ==========================
+Metric                      Performance indicator type
+=========================== ==========================
+`cost per transaction`_     KPI (mandatory)
+`user satisfaction`_        KPI (mandatory)
+`completion rate`_          KPI (mandatory)
+`digital take-up`_          KPI (mandatory)
+`live service usage`_       Standard
+`transactions by channel`_  Standard
+`completion at each stage`_ Standard
+`page load time`_           Standard
+`service uptime`_           Standard
+`transaction volumes`_      Optional
+`site visits`_              Optional
+`device usage`_             Optional
+`browser usage`_            Optional
+`help usage`_               Optional
+`bespoke`_                  Optional
+digital transaction volumes *tbc*
+=========================== ==========================
+
+NOTE: Are there any missing - is there an order/precedence?
+
+Presenting metrics
+==================
+
+The Performance Platform provides a number of dashboard 'types' dependent on the needs of the service manager.  The primary dashboard type is the `transactional service` dashboard.
+
+Metrics are displayed in `modules` within a dashboard.
+
+Where metrics need to be aggragated across a number of `transactional` services to present an over-arching `organisational service` view of performance, a number of alternative dashboard templates can be used.
+
+.. _cost per transaction: cost-per-transaction
+.. _user satisfaction: user-satisfaction
+.. _completion rate: completion-rate
+.. _digital take-up: digital-take-up
+.. _live service usage: live-service-usage
+.. _transactions by channel: transactions-by-channel
+.. _transaction volumes: transaction-volumes
+.. _completion at each stage: completion-at-each-stage
+.. _page load time: page-load-time
+.. _service uptime: service-uptime
+.. _site visits: site-visits
+.. _device usage: usage-by-device
+.. _browser usage: usage-by-browser
+.. _help usage: help-usage
+.. _bespoke: bespoke
+
+.. toctree::
+  :hidden:
+
+  cost-per-transaction/index
+  user-satisfaction/index
+  completion-rate/index
+  digital-take-up/index
+  live-service-usage/index
+  transactions-by-channel/index
+  completion-at-each-stage/index
+  page-load-time/index
+  service-uptime/index
+  transaction-volumes/index
+  site-visits/index
+  device-usage/index
+  browser-usage/index
+  help-usage/index
+  bespoke/index

--- a/user-manual/metrics/live-service-usage/index.rst
+++ b/user-manual/metrics/live-service-usage/index.rst
@@ -1,0 +1,46 @@
+.. _live-service-usage:
+
+Live service usage
+##################
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/page-load-time/index.rst
+++ b/user-manual/metrics/page-load-time/index.rst
@@ -1,0 +1,46 @@
+.. _page-load-time:
+
+Page load time
+##############
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/service-uptime/index.rst
+++ b/user-manual/metrics/service-uptime/index.rst
@@ -1,0 +1,46 @@
+.. _service-uptime:
+
+Service uptime
+##############
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/site-visits/index.rst
+++ b/user-manual/metrics/site-visits/index.rst
@@ -1,0 +1,46 @@
+.. _site-visits:
+
+Site visits
+###########
+
+Descritpion
+-----------
+
+*outline what the metric provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/transaction-volumes/index.rst
+++ b/user-manual/metrics/transaction-volumes/index.rst
@@ -1,0 +1,46 @@
+.. _transaction-volumes:
+
+Transaction volumes
+###################
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/transactions-by-channel/index.rst
+++ b/user-manual/metrics/transactions-by-channel/index.rst
@@ -1,0 +1,46 @@
+.. _transactions-by-channel:
+
+Transactions by channel
+#######################
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/metrics/user-satisfaction/index.rst
+++ b/user-manual/metrics/user-satisfaction/index.rst
@@ -1,0 +1,46 @@
+.. _user-satisfaction:
+
+User satisfaction
+#################
+
+Descritpion
+-----------
+
+*outline what the module provides*
+
+*outline considerations for where the data is sourced from e.g. gov.uk OR department system*
+
+Benefits
+--------
+
+Visualisation
+-------------
+
+*Insert visualisation here*
+
+*Insert rationale for the visualisation*
+
+Technical details
+-----------------
+
+Configuration
+-------------
+
+*description on how to configure this visualisation*
+
+*how to set filters nad group*
+
+Data source
+-----------
+
+*Identify data source - where this data is/can be sourced from*
+
+*identify collector type - include link to how to build/configure the collector*
+
+Dependencies
+------------
+
+*list of who does what*
+
+.. toctree::
+  :maxdepth: 2

--- a/user-manual/modelling-services/index.rst
+++ b/user-manual/modelling-services/index.rst
@@ -1,0 +1,64 @@
+.. _modelling-services:
+
+Modelling services
+##################
+
+Across government, departments and agencies manage the running of services supporting individuals and business .....
+
+Blurb about 'service' is an overloaded word!
+
+Within eqach organisation, the facilties offered to users will have their own 'language' to describe....
+
+In order to present a consistent and coherent view of how government services are performing in supporting the needs of their users, the 
+performance platform needs a structured view of 'service' to allow dashboards to be presented at the right level and metrics
+preesented in a way that supports comparison 
+
+The basic model
+===============
+
+Quick section on the intersect between 'purpose'(facility), process, exposure of process to users as transactions
+
+Intro to 'org service groups' assigned to orgs/dept/agencies
+
+Alow preakdown to suite org
+
+Interoduce 'transaction' in terms of the net effect of supporting the user reaching a goal
+
+The service 'hierarchy' - intro to 'type
+========================================
+
+Show our hierarchy, its gflexibility and example mappings onto existing service - choose complex/mid/simple
+
+Understand service and data in context of implementation
+========================================================
+
+How to start mapping the data to support metrics from underlying implementations
+
+NOTE: service implementation should absolutely aim to minimise impact of way metrics are presented - de-couple the data source and aggregation from the metric
+
+Links to Data group/type/set
+
+Rules - map the data group to the highest level of metric aggregation required
+create datasets as high up the hierarchy as long as data from multiple sources can be uniquely identified within the set
+
+examples
+
+Considerations for presentation
+-------------------------------
+
+How is the data to be converted to metrics and for what audience
+
+* `Organisational view of service`_ - orgs will aggregate within the hierarchy of a specific organisational service (or group)
+* `Transactional user view of service`_ - individuals will aggragate at the level of associated transactions that provide them with their goal
+
+The two are not exclusive - metrics can be presented from the same underlying datasets - service managers must be cogniscent of their options when modelling how their service performance data is to be used
+
+.. _`Organisational view of service`: organisational-view
+.. _`Transactional user view of service`: transaction-user-view
+
+.. toctree::
+  :hidden:
+
+  organisational-view/index
+  transaction-user-view/index
+

--- a/user-manual/modelling-services/organisational-view/index.rst
+++ b/user-manual/modelling-services/organisational-view/index.rst
@@ -1,0 +1,11 @@
+.. _organisational-view:
+
+Organisational view of performance
+##################################
+
+look at how service can be modelled to support service managers - navigable tree 
+
+data aggregation for metrics presented in tiers
+
+examples - SLC/DVSA
+

--- a/user-manual/modelling-services/transaction-user-view/index.rst
+++ b/user-manual/modelling-services/transaction-user-view/index.rst
@@ -1,0 +1,10 @@
+.. _transaction-user-view:
+
+Transactional user view of service
+##################################
+
+look at how service can be modelled to support users managers - flat model based on associated transactions 
+
+data aggregation for metrics presented in flat aggregate 
+
+examples - DVSA - learning to drive

--- a/user-manual/news.rst
+++ b/user-manual/news.rst
@@ -1,0 +1,8 @@
+.. _news:
+
+User manual changes
+###################
+
+Can we have a feed?
+
+otherwise - updates to manuala contents (which should refer to changes to features and support)

--- a/user-manual/platform-benefits.rst
+++ b/user-manual/platform-benefits.rst
@@ -1,0 +1,62 @@
+.. _platform-benefits:
+
+Platform benefits
+#################
+
+The Performance Platform is primarily built for `Service managers`_,
+giving them a single place to see how their services are performing, how
+people are accessing and using services, and to identify where they can
+be improved.
+
+The Performance Platform is open by design allowing individuals across
+government, the public, businesses and other organisations access to the
+same information. Allowing such broad overview and insight allows us to
+understand how citizens use government services, focus where
+improvements can be made and lead to higher levels of engagement and
+improved user satisfaction and efficiency. The platform is a key tool in
+government’s commitment to transparency and open-data.
+
+Being open, there is a requirement that any data the platform receives
+and presents does not allow for the identification of any individual or
+their personal details, or exposes any government or organisation
+sensitive information. All data the platform receives must be
+de-sensitised, anonymised and where required aggregated.
+
+In broad terms, any data that would be made available for a Freedom of
+Information Act (FOIA) request is at a suitable level for presenting on
+a publically accessible site.
+
+The aim is to:
+
+-  Enable government to make **decisions** based on data
+-  **Automate** data collection, ending repetitive manual reporting
+   efforts
+-  Do the hard work to make presentation and interpretation of data
+   **simple** for users
+-  Be **open** to any government service supplying their data and
+   customising their outputs, and **open** to the public
+-  Be **independent** of proprietary monitoring software
+-  **Provoke** rather than replace detailed analysis
+
+The goal
+--------
+Statement on what the aim of the performance platomr is
+
+Shared information
+------------------
+Statement on the benefits of sharing a consistent set of performance
+metrics across services fro government offers
+
+Benefits to Service Managers
+----------------------------
+Statement re. what Service Managers gain
+
+Benefits to government
+----------------------
+Statement re. what government and its departments gain
+
+Benefits to citizens
+--------------------
+Statement re. what citizens gain
+
+.. _Service managers: https://gov.uk/service-manual/service-managers

--- a/user-manual/platform-overview.rst
+++ b/user-manual/platform-overview.rst
@@ -1,0 +1,28 @@
+.. _platform-overview:
+
+Platform overview
+#################
+
+Government handles over one and a half billion transactions every year, allowing the exchange of information, money, permission, goods and services.
+
+Ministers, senior officials, and staff at the centre of government rely on more automated, accessible, and actionable sets of data relating to the services government deliver.
+
+Making data available simply and consistently allows users to see how services are performing and provides a consistent way to analyse information and drive improvements.
+
+The `Performance Platform`_ is the way Government does this. The platform currently provides three views onto performance data:
+
+-  `Transactions Explorer`_ - shows the number of transactions processed each year across government departments, agencies and other public bodies
+-  `Services Dashboard`_ - displays detailed performance data on transactional services provided through `GOV.UK`_
+-  `GOV.UK performance`_ - presents a dashboard of comparative data for the number of visitors to `GOV.UK`_ and the content they view information
+
+There are more than 760 transactional services offered to citizens and organisations across government. At an operational level, management information is collected ‘in-house’ at a department level from many sources and processed across many systems.
+
+The Performance Platform provides the single place where service performance metrics can be viewed in a consistent and authoritative way. 
+
+The platform allows both realtime and non-realtime data to be brought together from these sources, combined and presented in a graphical form to allow rapid comparison between services against a common set of performance metrics and enable focussed decision making.
+
+.. _Performance Platform: https://gov.uk/performance
+.. _Transactions Explorer: https://www.gov.uk/performance/transactions-explorer
+.. _Services Dashboard: https://gov.uk/performance/services
+.. _GOV.UK: https://www.gov.uk/
+.. _GOV.UK performance: https://www.gov.uk/performance/dashboard

--- a/user-manual/support/index.rst
+++ b/user-manual/support/index.rst
@@ -1,0 +1,53 @@
+.. _support:
+
+Support for users
+#################
+
+What support do/will we provide for users:
+
+Dashboard Inception
+===================
+* Business Analysis 
+* Technical analysis
+* Defining collectors
+* Schemas
+* Integration 
+* Configuration
+
+......
+
+Dashboard operation
+===================
+Dashboard problems
+==================
+...
+
+Platform problems
+=================
+...
+
+Data access problems
+====================
+* Read api
+* Write api
+* Tokens
+* Analytics/pingdom providers
+
+....
+
+Responsibilities
+================
+
+* What are we responsible for 
+* What are service managers, organisation teams and developers (in-house/external) responsible for
+
+*e.g.*
+
+* Dashboards config probs
+* Content/narrative change
+* Changes to links
+* Fail to upload
+* Collectors not running (our/theirs)
+* Scheduled downtime notification etc
+* user manual errors/changes
+

--- a/user-manual/users/decision-makers/index.rst
+++ b/user-manual/users/decision-makers/index.rst
@@ -1,0 +1,8 @@
+.. _decision-makers:
+
+Guides for decision makers
+##########################
+
+BIG LIST O' STUFF!!!!
+
+maybe sectioned?

--- a/user-manual/users/implementers/index.rst
+++ b/user-manual/users/implementers/index.rst
@@ -1,0 +1,8 @@
+.. _implementers:
+
+Guides for implementers
+#######################
+
+BIG LIST O' STUFF!!!!
+
+maybe sectioned?

--- a/user-manual/users/index.rst
+++ b/user-manual/users/index.rst
@@ -1,0 +1,25 @@
+.. _users:
+
+Guides for users
+################
+
+Depending on your role and what you need to understand about performance metrics and the platform, 
+the links below will list the sections of the manual the should be most useful
+
+Roles
+=====
+
+* `Decision makers`_ - Ministers, Permanent Secretarys, CDIO's and influencers: high level information about the benefits of measuring performance and why the platfomr is the right way
+* `Managers`_ - Service, Delivery and Product managers: Overview information on what metrics are required and recommended and the ways these can be presented on dashboards to provide you with the information to manage how services perform
+* `Implementers`_ - Development teams responsible for data integration, configuring the platform and configuring dashboards
+
+.. _`Decision makers`: decision-makers
+.. _`Managers`: service-managers
+.. _`Implementers`: implementers
+
+.. toctree::
+  :hidden:
+
+  decision-makers/index
+  service-managers/index
+  implementers/index 

--- a/user-manual/users/service-managers/index.rst
+++ b/user-manual/users/service-managers/index.rst
@@ -1,0 +1,8 @@
+.. _service-managers:
+
+Guides for service managers
+###########################
+
+BIG LIST O' STUFF!!!!
+
+maybe sectioned?


### PR DESCRIPTION
Create skeleton topics for user manual
Currently unstructured'ish - placeholders for content to be reviewed
Created as a 'user-manual' child of all docs - plan to move this to top level
when agreed
