### PR TITLE
Improve documentation

### DIFF
--- a/api/write-api.rst
+++ b/api/write-api.rst
@@ -106,3 +106,13 @@ Emptying a data set
   :reqheader Authorization: required OAuth token to authenticate the request
 
   :statuscode 200: data set now contains no records
+
+Client implementations
+======================
+
+We provide several implementations of client code to talk to the Performance Platform:
+
+- `Go <https://github.com/alphagov/performanceplatform-client.go>`_
+- `Java implementation <https://github.com/alphagov/pp-db-collector-template>`_ intended to periodically poll a JDBC data store and push data Performance Platform
+- `JavaScript <https://github.com/alphagov/performanceplatform-client.js>`_
+- `Python <https://github.com/alphagov/performanceplatform-client.py>`_

--- a/api/write-api.rst
+++ b/api/write-api.rst
@@ -1,5 +1,5 @@
 Write API
-=========
+#########
 
 We expose a simple HTTP API for storing data in the Performance
 Platform.
@@ -23,6 +23,8 @@ The client request:
 
 The `backdropsend <https://github.com/alphagov/backdropsend>`_ tool provides a command line interface to the API. This adds support for retrying.
 
+Adding data
+===========
 
 .. http:post:: /data/(string:data_group)/(string:data_type)
 
@@ -71,6 +73,8 @@ The `backdropsend <https://github.com/alphagov/backdropsend>`_ tool provides a c
 
   :statuscode 200: data from the request body was stored in the data set
 
+Emptying a data set
+===================
 
 .. http:put:: /data/(string:data_group)/(string:data_type)
 

--- a/api/write-api.rst
+++ b/api/write-api.rst
@@ -21,7 +21,7 @@ The client request:
 - must have a valid `Authorization header <https://tools.ietf.org/html/rfc6750#section-2.1>`_
 
 
-The `backdropsend <https://github.com/alphagov/backdropsend backdrop-send>`_ tool provides a command line interface to the API. This adds support for retrying.
+The `backdropsend <https://github.com/alphagov/backdropsend>`_ tool provides a command line interface to the API. This adds support for retrying.
 
 
 .. http:post:: /data/(string:data_group)/(string:data_type)

--- a/glossary.rst
+++ b/glossary.rst
@@ -1,0 +1,65 @@
+Glossary
+========
+
+.. glossary::
+
+  Aggregate
+    Applying a function to a Measure, such as summing, calculating the mean etc
+
+  Backdrop
+    An application that is part of the performance platform. It provides the `read and write API <https://github.com/alphagov/backdrop>`_ for data.
+
+  Chart
+    A graphical representation of a Measure and a Dimension (eg number of applications by channel)
+
+  Dashboard
+    A page showing multiple metrics, typically for a single :term:`service`
+
+  Data group
+    Something
+
+  Dataset
+    A collection of data of a particular type. In relational terms, this is a table.
+    In non-relational terms, this is a document.
+
+  Data type
+    Each :term:`Dataset` stores a particular type of data, eg current traffic volume
+
+  Dimension
+    A non-numeric type of :term: `Field` eg an operating system or browser
+
+  Element
+    A component of a Visualisation such as a chart or aggregate summary
+
+  Field
+    A 'column' in a dataset
+
+  Measure
+    A numeric type of :term: `Field`, eg number of applications. A Measure may be aggregated
+
+  Metric
+    A specific data series, eg completion rate, user satisfaction, page load time, uptime etc
+
+  Module
+    A module is a :term:`metric` and a :term:`visualisation` together, eg digital take-up shown as a line chart
+
+  Observation
+    A 'row' in a dataset
+
+  Service
+    Central govenment in the UK operates 766 services, eg Renew you car tax, Apply for Carer's Allowance, Book a practical driving test etc
+
+  Service Group
+    A group of closely related services, eg Carer's Allowance service group includes applications, existing claims, appeals etc
+
+  Spotlight
+    An application that is part of the performance platform. It is responsible for `rendering data <https://github.com/alphagov/backdrop>`_ from the :term:`Backdrop` API to display visualisations of service performance
+
+  Stageprompt
+    A JavaScript library that provides an adapter over analytics software
+
+  Transaction
+    Central government in the UK handles about 1.5 billion transactions a year, including applications, renewals, bookings, claims etc
+
+  Visualisation
+    A set of Elements using the Measures and Dimensions from the Dataset

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,10 @@
-:toctree:
-  :maxdepth: 1
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+
+    self
+    api/write-api
+    glossary
 
 
 Get a Performance Dashboard
@@ -52,7 +57,7 @@ There are 3 standard ways data can be put into a dashboard. You can choose to us
 
    The analytics data will be able to track how a service is used, eg how many people view a service online, complete an online application or access the service with their mobile phone.
 
-   You can use :ref:`Stageprompt <stageprompt>` when you share your analytics data. This provides a javascript wrapper around your data, so that if you change analytics provider in the future, you will not have to make changes to the connection you have with the Performance Platform.
+   You can use :term:`Stageprompt <stageprompt>` when you share your analytics data. This provides a javascript wrapper around your data, so that if you change analytics provider in the future, you will not have to make changes to the connection you have with the Performance Platform.
 
 2. Your developers can write code that automatically sends the latest data about your service to a dashboard (using the platform’s :doc:`write API <api/write-api>`). This will mean you don’t have to spend time manually updating spreadsheets.
 
@@ -92,5 +97,5 @@ Make corrections to dashboard data
 
 Occasionally data in the dashboards may be incorrect. You can correct the data in your dashboard by:
 
-- 	contacting the performance team if it’s data collected for you
--	uploading the revised data to your spreadsheet - this will automatically display in the dashboard
+- contacting the performance team if it’s data collected for you
+- uploading the revised data to your spreadsheet - this will automatically display in the dashboard


### PR DESCRIPTION
As we move towards providing self-service functionality, we need to provide
better documentation describing the product and how to integrate with it.

The existing documentation covers "As someone interested in dashboards,
I want to know how I get one."

This pull request is intended to cover "Now that I have created a
dashboard via the self-service admin tool, how can my technical team
automate putting data into the Performance Platform?"

For this, I've tried to define common language. There is some unfortunately
technical language that is related to the domain of OLAP, dimensional data
warehouses and Management Information.

I felt it necessary to define those, since they should form the basis of any
model that we're working with.

I've also added a bit around the write API, and pointed to the clients which
we support for talking to that API.

Supporting architecture and services which aren't related to those tasks
have been deliberately excluded from the changes in this pull request.

See https://www.agileplannerapp.com/boards/15088/cards/9248